### PR TITLE
BUILD-4839 Update the release workflow to the latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,13 @@ on:
   release:
     types:
       - published
-  workflow_dispatch:
-
-env:
-  PYTHONUNBUFFERED: 1
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@8c85ff24955eda4c81938fd8c45943ccc8974c68 # 5.0.14
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: false
       mavenCentralSync: true


### PR DESCRIPTION
Release Action version 5.5.0 has been published. Update the release workflow to use the v5 branch for future updates. More details are at https://github.com/SonarSource/gh-action_release/releases.