### PR TITLE
PACKMP-43 Fix the Analysis Processing team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/orchestration-processing-squad
+.github/CODEOWNERS @sonarsource/quality-processing-squad


### PR DESCRIPTION
## Summary
Updates the GitHub team name in `.github/CODEOWNERS` from `orchestration-processing-squad` to `quality-processing-squad` following the team's move from Code Orchestration to Code Quality.

## Changes
- Updated `.github/CODEOWNERS` to reference `@sonarsource/quality-processing-squad`

## Related
- Jira: SC-41026

🤖 Generated with [Claude Code](https://claude.com/claude-code)