### PR TITLE
PACKMP-46 Change Code Owners and Slack notification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-.github/CODEOWNERS @sonarsource/quality-processing-squad
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sonarsource/code-quality-ci-experience-squad

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       publishToBinaries: false
       mavenCentralSync: true
-      slackChannel: team-sonarqube-build
+      slackChannel: ops-ci-experience


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration updates:**
  - Updated `.github/CODEOWNERS` to assign the repository to `@sonarsource/code-quality-ci-experience-squad`.
  - Changed the `slackChannel` in `.github/workflows/release.yml` from `team-sonarqube-build` to `ops-ci-experience`.

<sub>This will update automatically on new commits.</sub>