### PR TITLE
PACKMP-47 Bump maven version from 3.9.11 to 3.9.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <license.name>GNU LGPL v3</license.name>
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-packaging-maven-plugin</gitRepositoryName>
-    <mavenVersion>3.9.11</mavenVersion>
+    <mavenVersion>3.9.16</mavenVersion>
     <sonar.exclusions>target/generated-sources/**/*</sonar.exclusions>
     <sonar.sca.exclusions>src/it/**</sonar.sca.exclusions>
   </properties>


### PR DESCRIPTION
There is a vulnerability with the transitive dependency to plexus-utils (v3.6.0). Maven 3.9.16 uses 3.6.1 which handled this vulnerability